### PR TITLE
Fix #118 - fix ci badge link MOODLE_401_STABLE branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/catalyst/moodle-tool_securityquestions/ci.yml?branch=MOODLE_401_STABLE)
+[![ci](https://github.com/catalyst/moodle-tool_securityquestions/actions/workflows/ci.yml/badge.svg?branch=MOODLE_401_STABLE)](https://github.com/catalyst/moodle-tool_securityquestions/actions/workflows/ci.yml?branch=MOODLE_401_STABLE)
 
 # Security Questions 2FA
 


### PR DESCRIPTION
Fix #118 - fix ci badge link MOODLE_401_STABLE branch